### PR TITLE
missing css file

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,6 @@ module.exports = {
 
     this.app.import(app.bowerDirectory + '/moment/moment.js');
     this.app.import(app.bowerDirectory + '/bootstrap-daterangepicker/daterangepicker.js');
-    this.app.import(app.bowerDirectory + '/bootstrap-daterangepicker/daterangepicker-bs3.css');
+    this.app.import(app.bowerDirectory + '/bootstrap-daterangepicker/daterangepicker.css');
   }
 };


### PR DESCRIPTION
latest version does not have *-bs2.css file
https://github.com/dangrossman/bootstrap-daterangepicker/tree/v2.0.6
